### PR TITLE
all ACM edits for Section 5, files target and qualifcations

### DIFF
--- a/src/qualifications.xml
+++ b/src/qualifications.xml
@@ -2,8 +2,9 @@
 
         <t>Many tests have preconditions which are required to
         assure their validity. Examples include: the presence or
-        nonpresence of cross traffic on specific subpaths;
-        negotiating ECN; and appropriate preloading to put reactive
+        non-presence of cross traffic on specific subpaths;
+        negotiating ECN; and appropriate preamble packet stream 
+        to testing to put reactive
         network elements into the proper states 
         <xref target="RFC7312" />. If preconditions are not
         properly satisfied for some reason, the tests should be

--- a/src/target.xml
+++ b/src/target.xml
@@ -10,7 +10,10 @@
         are in units that make sense to upper layers: payload bytes
         delivered to the application, above TCP. They exclude
         overheads associated with TCP and IP headers, retransmits
-        and other protocols (e.g. DNS).</t>
+        and other protocols (e.g. DNS). Note that IP-based network 
+        services include TCP headers and retransmissions as part of 
+        delivered payload, and this difference is recognized in 
+        calculations below (header_overhead). </t>
 
         <t>Other end-to-end parameters defined in 
         <xref target="terminology" /> include the effective


### PR DESCRIPTION
Rates based on TCP payload don't match the IP packet transfer service, TCP and other headers
are IP payload and I could make an argument that IPv6 (Dest) Options are part 
of user traffic.  We need to highlight this difference, at least.
Later, the difference between delivered and IP is called header_overhead.
If we compare to "real" TCP for validation, the bytes delivered 
as estimated by the model should compare directly.
