### PR TITLE
ACM edits for derive.xml (Appendix A)

### DIFF
--- a/src/derive.xml
+++ b/src/derive.xml
@@ -11,7 +11,7 @@
       calculations using different assumptions.</t>
 
       <t>It may seem out of place to allow such latitude in a
-      measurement standard, but this section provides offsetting
+      measurement method, but this section provides offsetting
       requirements.</t>
 
       <t>The estimates provided by these models make the most sense


### PR DESCRIPTION
SD's comment:
This document is targeting Experimental, but I did see 

   It may seem out of place to allow such latitude in a measurement
   standard, but this section provides offsetting requirements.
   
in Appendix A, which seems to say this is a standard. Perhaps that could be reworded?
[ACM] yes, done