### PR TITLE
ACM edits for introduction.xml

### DIFF
--- a/src/introduction.xml
+++ b/src/introduction.xml
@@ -32,7 +32,7 @@
       bit rate streams, etc.) and statistical
       criteria for evaluating packet transfer. The temporal
       structure of the test streams mimic transport protocol
-      behavior over the complete path, the statistical criteria
+      behavior over the complete path; the statistical criteria
       models the transport protocol's response to less than ideal
       IP packet transfer.</t>
 
@@ -40,7 +40,7 @@
       describes an alternative to the approach
       presented in "A Framework for Defining Empirical Bulk
       Transfer Capacity Metrics" 
-      <xref target="RFC3148" />. In the future, other Model Based
+      <xref target="RFC3148" />. Other Model Based
       Metrics may cover other applications and transports, such as
       VoIP over UDP and RTP, and new transport protocols.</t>
 


### PR DESCRIPTION
[ACM] INTRO comments start
It's a nit, but 

   The temporal
   structure of the test streams mimic transport protocol behavior over
   the complete path, the statistical criteria models the transport
   protocol's response to less than ideal IP packet transfer.
   
seems like a run-on sentence. Maybe split into two sentences at the comma, or use a semicolon?
[ACM] semicolon I think...

I often see reviewers comment on references to "in the future" and "Today" in RFCs that live forever. I think you can just drop "in the future" from 

   In the future,
   other Model Based Metrics may cover other applications and
   transports, such as VoIP over UDP and RTP, and new transport
   protocols.
[ACM] dropped the phrase.   
but you might want to search for at least those terms in the document.
[ACM] see sections 5.4, 6.0, and 8.4 for other occurrences 
