### PR TITLE
ACM edits for overview.xml

### DIFF
--- a/src/overview.xml
+++ b/src/overview.xml
@@ -21,7 +21,7 @@
       new mechanisms to implement the required temporal structure.
       (One group of tests, the standing queue tests described in 
       <xref target="standing_queue" />, don't correspond to
-      existing IPPM metrics, but suitable metrics can be patterned
+      existing IPPM metrics, but suitable new IPPM metrics can be patterned
       after the existing definitions.)</t>
 
       <t><xref target="fig1" /> shows the MBM modeling and measurement
@@ -74,7 +74,8 @@ Traffic parameters |            | Statistical criteria
     ----V----------------------------------V--- |
         | |  |                             | |  |
         V V  V                             V V  V
-    fail/inconclusive            pass/fail/inconclusive    
+    fail/inconclusive            pass/fail/inconclusive  
+     (test status)                   (test result)  
 ]]></artwork>
 <postamble>Overall Modeling Framework</postamble></figure>
 
@@ -97,8 +98,8 @@ Traffic parameters |            | Statistical criteria
       <t>
       <xref target="results" /> describes packet transfer statistics
       and methods to test them against the statistical criteria provided by the
-      mathematical models. Since the statistical criteria are typically
-       for the complete path (a composition of subpaths)
+      mathematical models. Since the statistical criteria typically
+      apply to the complete path (a composition of subpaths)
       <xref target="RFC6049" />, in situ testing requires that the
       end-to-end statistical criteria be apportioned as separate
       criteria for each subpath. Subpaths that are expected to be
@@ -129,7 +130,7 @@ Traffic parameters |            | Statistical criteria
 
       <t>In 
       <xref target="examples" /> we present an example TIDS that
-      might be representative of HD video, and illustrate how Model
+      might be representative of High Definition (HD) video, and illustrate how Model
       Based Metrics can be used to address difficult measurement
       situations, such as confirming that inter-carrier exchanges
       have sufficient performance and capacity to deliver HD video


### PR DESCRIPTION
[ACM] OVERVIEW
This text

   (One group of tests, the standing queue tests described in
   Section 8.2, don't correspond to existing IPPM metrics, but suitable
   metrics can be patterned after the existing definitions.)
   
was passive enough that I don't know whether you're talking about IPPM developing new metrics, or about something else (perhaps work that developers will do on their own). If you mean what I think you mean, just changing to "suitable new IPPM metrics" would be clear to me, but I'm guessing.
[ACM] suggest8ion workd for me.

In Figure 1, I was confused by the distinction between "fail/inconclusive" and "pass/fail/inconclusive". Maybe not for the document, but could you educate me? I think I understand that you have to do Delivery Evaluation to determine "pass/fail/inconclusive", and the description of Section 8 further down the Overview confirmed what I was thinking here, but I'm not understanding what "fail/inconclusive" is telling me about traffic pattern generation, unless it's something like "failed due to configuration errors" (and that's a guess, based on text at the end of Section 4.2).
[ACM] labelled these as test status and test result.

I had to read 

   Since the statistical criteria are typically for the
   complete path (a composition of subpaths) [RFC6049]
   
a couple of times to parse "typically for". Is this saying 

   Since the statistical criteria typically apply to the
   complete path (a composition of subpaths) [RFC6049]
   
?
[ACM] Yes, that's better wording.

"HD video" is probably clear enough for now, but expanding "HD" on first use might be helpful for readers in the future.

<AD whining>

The more I read, the more I found the mixed forms permitted in

   Note that terms containing underscores (rather than spaces) appear in
   equations in the modeling sections.  In some cases both forms are
   used for aesthetic reasons, they do not have different meanings.
   
confusing. When "test path:", with no underscores, is immediately followed by "test_path_RTT:", with underscores, the usage looks entirely random to the first-time reader, and there are some formulas that use the form with no underscores, that don't stand out as formulas on first reading ("2*target_window_size" is obviously a mathematical expression, but without underscores, it would be less obvious). I'm hesitant to suggest that you make a global change to use underscores during AD Review because that seems really likely to introduce errors, but I really wish I'd said that earlier in the process. Do the right thing.

</AD whining>
[ACM] this would be a major edit -  Matt ???