### PR TITLE
ACM edits for terminology.xml

### DIFF
--- a/src/terminology.xml
+++ b/src/terminology.xml
@@ -27,14 +27,14 @@
           Target RTT and Target MTU as described below.</t>
           <t hangText='Target Data Rate:'>The specified application
           data rate required for an application's proper operation.
-          Conventional BTC metrics are focused on the Target Data
+          Conventional Bulk Transport Capacity (BTC) metrics are focused on the Target Data
           Rate, however these metrics had little or no predictive
           value because they do not consider the effects of the
           other two parameters of the Target Transport Performance,
           the RTT and MTU of the complete paths.</t>
           <t hangText='Target RTT (Round Trip Time):'>The specified
           baseline (minimum) RTT of the longest complete path over
-          which the user expects to be able meet the target
+          which the user expects to be able to meet the target
           performance. TCP and other transport protocol's ability
           to compensate for path problems is generally proportional
           to the number of round trips per second. The Target RTT
@@ -50,7 +50,7 @@
           <t hangText='Target MTU (Maximum Transmission Unit):'>The
           specified maximum MTU supported by the complete path the
           over which the application expects to meet the target
-          performance. Assume 1500 Byte MTU unless otherwise
+          performance. Assume a 1500 Byte MTU when testing unless otherwise
           specified. If some subpath has a smaller MTU, then it
           becomes the Target MTU for the complete path, and all
           model calculations and subpath tests must use the same
@@ -63,7 +63,7 @@
           RTT of the complete path is target_RTT.</t>
           <t hangText="Fully Specified Targeted IP Diagnostic Suite (FS-TIDS):">
           A TIDS together with additional specification such as
-          "type-p", etc which are out of scope for this document,
+          "type-p" <xref target="RFC2330" />, etc. which are out of scope for this document,
           but need to be drawn from other standards documents.</t>
           <t hangText="Bulk Transport Capacity:">Bulk Transport
           Capacity Metrics evaluate an Internet path's ability to
@@ -114,7 +114,7 @@
 
       <t>Terminology about paths, etc. See 
       <xref target="RFC2330" /> and 
-      <xref target="RFC7398" />.</t>
+      <xref target="RFC7398" /> for existing terms and definitions.</t>
 
       <t>
         <list style="hanging">
@@ -200,7 +200,8 @@
           delivered through the bottleneck the front path must have
           sufficient buffering to absorb any data bursts at the
           dimensions (duration and IP rate) implied by the ACK
-          stream, potentially doubled during slowstart. If the
+          stream (and potentially twice that buffer to absorb 
+          overshoot in slowstart). If the
           return path is not altering the ACK stream, then the
           implied bottleneck IP capacity will be the same as the
           bottleneck IP capacity. See 
@@ -210,7 +211,7 @@
           corresponds to the IP capacity of the data sender's
           interface. Due to sender efficiency algorithms including
           technologies such as TCP segmentation offload (TSO),
-          nearly all moderns servers deliver data in bursts at full
+          nearly all modern servers deliver data in bursts at full
           interface link rate. Today 1 or 10 Gb/s are typical.</t>
           <t hangText="Header_overhead:">The IP and TCP header
           sizes, which are the portion of each MTU not available
@@ -232,6 +233,7 @@
       <t>
         <list style="hanging">
           <t hangText="Window [size]:">The total quantity of data
+          carried by packets in-flight 
           plus the data represented by ACKs circulating in the
           network is referred to as the window. See 
           <xref target="tcp" />. Sometimes used with other
@@ -331,7 +333,7 @@
         <t hangText="paced bursts:">Send bursts on a timer. Specify
         any 3 of: average data rate, packet size, burst size
         (number of packets) and burst headway (burst start to
-        start). By default the bursts are assumed full sender
+        start). By default the bursts are assumed to occur at full sender
         interface rate, such that the packet headway within each
         burst is the minimum supported by the sender's interface.
         Under some conditions it is useful to explicitly specify
@@ -381,7 +383,7 @@
           load themselves. As such they may miss some details of
           the network's performance, but can serve as a useful
           reduced-cost proxy for a capacity test, for example to
-          support ongoing monitoring.</t>
+          support continuous production network monitoring.</t>
           <t hangText="Engineering tests:">Engineering tests
           evaluate how network algorithms (such as AQM and channel
           allocation) interact with TCP-style self clocked


### PR DESCRIPTION

[ACM] OVERVIEW
This text

   (One group of tests, the standing queue tests described in
   Section 8.2, don't correspond to existing IPPM metrics, but suitable
   metrics can be patterned after the existing definitions.)
   
was passive enough that I don't know whether you're talking about IPPM developing new metrics, or about something else (perhaps work that developers will do on their own). If you mean what I think you mean, just changing to "suitable new IPPM metrics" would be clear to me, but I'm guessing.
[ACM] suggest8ion workd for me.

In Figure 1, I was confused by the distinction between "fail/inconclusive" and "pass/fail/inconclusive". Maybe not for the document, but could you educate me? I think I understand that you have to do Delivery Evaluation to determine "pass/fail/inconclusive", and the description of Section 8 further down the Overview confirmed what I was thinking here, but I'm not understanding what "fail/inconclusive" is telling me about traffic pattern generation, unless it's something like "failed due to configuration errors" (and that's a guess, based on text at the end of Section 4.2).
[ACM] labelled these as test status and test result.

I had to read 

   Since the statistical criteria are typically for the
   complete path (a composition of subpaths) [RFC6049]
   
a couple of times to parse "typically for". Is this saying 

   Since the statistical criteria typically apply to the
   complete path (a composition of subpaths) [RFC6049]
   
?
[ACM] Yes, that's better wording.

"HD video" is probably clear enough for now, but expanding "HD" on first use might be helpful for readers in the future.

[ACM] Terminology

<AD whining>

The more I read, the more I found the mixed forms permitted in

   Note that terms containing underscores (rather than spaces) appear in
   equations in the modeling sections.  In some cases both forms are
   used for aesthetic reasons, they do not have different meanings.
   
confusing. When "test path:", with no underscores, is immediately followed by "test_path_RTT:", with underscores, the usage looks entirely random to the first-time reader, and there are some formulas that use the form with no underscores, that don't stand out as formulas on first reading ("2*target_window_size" is obviously a mathematical expression, but without underscores, it would be less obvious). I'm hesitant to suggest that you make a global change to use underscores during AD Review because that seems really likely to introduce errors, but I really wish I'd said that earlier in the process. Do the right thing.

</AD whining>
[ACM] this would be a major edit -  Matt ???  @@@@@@

"Bulk Transport Capacity" appears in the definition of "Target Transport Performance" before the definition of "Target Data Rate" where the term "BTC" first appears, but "Bulk Transport Capacity (BTC)" in the first case would have helped me figure out "BTC" on its first use in the document.

[ACM] Done

It's a nit, but s/able meet the target performance/able to meet the target performance/.

[ACM] Done

I wasn't sure who was assuming a 1500 Byte MTU when, in this text. 

   Target MTU (Maximum Transmission Unit):  The specified maximum MTU
      supported by the complete path the over which the application
      expects to meet the target performance.  Assume 1500 Byte MTU
      unless otherwise specified.
      
Did that mean "in this document", or "when testing", or something else?

[ACM] When testing, IMO.

I even know what "type-p" is in this text,

   Fully Specified Targeted IP Diagnostic Suite (FS-TIDS):  A TIDS
      together with additional specification such as "type-p", etc which
      are out of scope for this document,
      
but you could usefully provide a reference for that, and I'm not sure whether "out of scope for this document" means that they exist in other documents. I think you're saying that, but I'm not sure.

[ACM] yes, that's it.

In this text,

   Bulk Transport Capacity:  Bulk Transport Capacity Metrics evaluate an
      Internet path's ability to carry bulk data, such as large files,
      streaming (non-real time) video, and under some conditions, web
      images and other content

How would the reader know what conditions make these metrics applicable to web images and other content?

[ACM] There is a relationship, but the ability to deliver Web
      and images is mostly based on RTT (small file size)

"Terminology about paths, etc.  See [RFC2330] and [RFC7398]." is really terse. Do you mean that the list of terms following this are taken from these RFCs, or are you saying the reader should be aware of other terms defined in those RFCs that don't appear in that list of terms? Or is that just a header for the list of terms following? I started wondering that when I saw "Properties determined by the complete path and application.  These are described in more detail in Section 5.1." further down the page, and had the same question.

[ACM] Added "for existing terms and definitions" in the terminology about paths
      section.

In this text,

      Since TCP
      derives its clock from the data delivered through the bottleneck
      the front path must have sufficient buffering to absorb any data
      bursts at the dimensions (duration and IP rate) implied by the ACK
      stream, potentially doubled during slowstart.
      
is "doubling each RTT" more accurate here? And if you included a reference for slowstart, that would likely be helpful to some readers. It appears a bunch of times in the document, but RFC 5681 isn't referenced until much later than the terminology section. 

@@@@@  [ACM] I think this is explained later. ??
            (and potentially twice the buffer to absorb overshoot in slowstart)

It's a nit, but s/moderns servers/modern servers/.

[ACM]  found and fixed

I'm struggling with 

   Window [size]:  The total quantity of data plus the data represented
      by ACKs circulating in the network is referred to as the window.
      See Section 4.1. 
      
and I think it's because I don't understand the scope of "the total quantity of data". Does this need a qualifier? A bit further down, "pipe size" and "target_window_size" talk about "packets in flight (the window size)", which further confused me. Is that window size the same that's being defined here?

@@@@ [ACM] Yes, I think "packets in flight" needs to be added in the right place

"a more stringent TIDS validation procedures" needs help with a numbering mismatch.

@@@@ [ACM] I think Section 10 is correct

"By default the bursts are assumed full sender interface rate" is really hard to parse.

@@@@ [ACM] "assumed to occur at full..."

In this text,

   Monitoring tests:  Monitoring tests are designed to capture the most
      important aspects of a capacity test, but without presenting
      excessive ongoing load themselves.  As such they may miss some
      details of the network's performance, but can serve as a useful
      reduced-cost proxy for a capacity test, for example to support
      ongoing monitoring.
      
does "ongoing monitoring" mean "during engineering testing", or something else? 
[ACM] it means "continuous production network monitoring" IMO.