### PR TITLE
ACM edits for background.xml

### DIFF
--- a/src/background.xml
+++ b/src/background.xml
@@ -1,11 +1,11 @@
     <!-- ======================================================== 4 -->
     <section anchor="background" title="Background">
 
-      <t>At the time the IPPM WG was chartered, sound Bulk
+      <t>In 1997, when performance specification work began in the IETF (and the IPPM WG was chartered), sound Bulk
       Transport Capacity (BTC) measurement was known to be well beyond
-      our capabilities. Even at the time that Framework for Empirical 
+      our capabilities. Even when Framework for Empirical 
       BTC Metrics 
-      <xref target="RFC3148" /> was written we knew that we didn't
+      <xref target="RFC3148" /> was written, we knew that we didn't
       fully understand the problem. Now, by hindsight we understand
       why assessing BTC is such a hard problem:
       <list style="symbols">
@@ -20,7 +20,7 @@
         The network and transport protocols find an operating point
 	which balances between opposing forces:
 	the transport protocol pushing harder
-	(raising the data rate and or window)
+	(raising the data rate and/or window)
 	while the network pushes back
 	(raising packet loss ratio, RTT and/or ECN CE marks).
         By design TCP congestion control keeps
@@ -263,8 +263,8 @@
         load, but may fail in the field due to configuration
         errors, etc. and should be spot checked.</t>
 
-        <t>We are developing a tool that can perform many of the
-        tests described here 
+        <t>The tool that can perform many of the
+        tests is available from  
         <xref target="MBMSource" />.</t>
         <!-- @@ move? -->
       </section>


### PR DESCRIPTION
[ACM]  Background section 4 -=-=-=-=-=-=-=-

In this text,

   At the time the IPPM WG was chartered, 
   
I THINK thats something like 

   In 2006, when the IETF begain work on performance measurement,
   
which tells the reader the timeframe (I had to look - 2006 is the oldest charter in the datatracker) and removes a reference to a working group that is long-lived, but may conclude SOME day.

[ACM] IPPM started-out sharing a meeting slot with BMWG, in 1997. 

There's a "and or" with no "/" between them.
[ACM] ok

I suspect that the earlier Section 4.1 appears in the document, the clearer the document would be, within limits ... I learned things, and I imagine most readers would benefit from learning them before piling into the terminology section that uses these concepts freely.

@@@@ [ACM] This is worth considering Matt, but it's a tricky task with the
            sections in separate files. Same is suggested for 4.3.

SCTP is mentioned once in the document, 17 pages in. Is it worth being more explicit whether this document applies to specific protocols besides TCP? Much of the discussion is either "TCP" or "throughput maximizing protocols", SCTP is only mentioned once, and of course I wondered about DCCP ... 

[ACM] I remember reading "and other transport protocols" in earlier sections,
so I think we're covered.

This text

   We are developing a tool that can perform many of the tests described
   here [MBMSource].
   
won't age well in an RFC. Perhaps 

   The tool that can perform many of the tests described
   here is available from [MBMSource].
   
?
[ACM] ok

I suspect that moving Section 4.3 earlier in the document would also be helpful.

@@@@ [ACM]  also consider with the move above.